### PR TITLE
bugfix: puchaseItems should be always based on selectedPantryIds

### DIFF
--- a/pantry-web/package.json
+++ b/pantry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantry-web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
bugfix: puchaseItems should be always based on selectedPantryIds, when creating order or listing items
updating pantry-web version 