### PR TITLE
Patch v0.9.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # My Pantry
 
-<b>version: 0.9.8</b>
+<b>version: 0.9.9</b>
 
-- pantry-web: v.0.8.14
-- account-service: v0.4.9
-- pantry-service: v0.6.10
-- purchase-service: v0.4.7
+- pantry-web: v.0.8.15
+- account-service: v0.4.10
+- pantry-service: v0.6.11
+- purchase-service: v0.4.8
 
 ### In this version:
 

--- a/account-service/pom.xml
+++ b/account-service/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>account-service</artifactId>
-    <version>0.4.9</version>
+    <version>0.4.10</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/common-config-data/src/main/java/com/fcastro/kafka/config/KafkaEventConfig.java
+++ b/common-config-data/src/main/java/com/fcastro/kafka/config/KafkaEventConfig.java
@@ -2,6 +2,7 @@ package com.fcastro.kafka.config;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -12,6 +13,7 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.TopicBuilder;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
@@ -24,19 +26,31 @@ public class KafkaEventConfig<V extends Serializable> {
 
     private final KafkaConfigData kafkaConfigData;
 
-    private HashMap<String, Object> factoryProperties;
+    private HashMap<String, Object> producerFactoryProperties;
+    private HashMap<String, Object> consumerFactoryProperties;
 
     public KafkaEventConfig(KafkaConfigData kafkaConfigData) {
         this.kafkaConfigData = kafkaConfigData;
-        setFactoryProperties();
+        setProducerFactoryProperties();
+        setConsumerFactoryProperties();
     }
 
-    private void setFactoryProperties() {
-        factoryProperties = new HashMap<String, Object>();
-        factoryProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfigData.getBootstrapServersConfig());
-        factoryProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        factoryProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        factoryProperties.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaConfigData.getGroup());
+    private void setProducerFactoryProperties() {
+        producerFactoryProperties = new HashMap<String, Object>();
+        producerFactoryProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfigData.getBootstrapServersConfig());
+        producerFactoryProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        producerFactoryProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        producerFactoryProperties.put(ProducerConfig.ACKS_CONFIG, "1"); //ACKS= 1 (ack only by  the leader)
+    }
+
+    private void setConsumerFactoryProperties() {
+        consumerFactoryProperties = new HashMap<String, Object>();
+        consumerFactoryProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfigData.getBootstrapServersConfig());
+        consumerFactoryProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerFactoryProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        consumerFactoryProperties.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaConfigData.getGroup());
+        consumerFactoryProperties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        //consumerFactoryProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     }
 
     @Bean
@@ -47,13 +61,14 @@ public class KafkaEventConfig<V extends Serializable> {
         eventDeserializer.addTrustedPackages("*");
         eventDeserializer.setUseTypeMapperForKey(true);
 
-        return new DefaultKafkaConsumerFactory<>(factoryProperties, new StringDeserializer(), eventDeserializer);
+        return new DefaultKafkaConsumerFactory<>(consumerFactoryProperties, new StringDeserializer(), eventDeserializer);
     }
 
     @Bean
     public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, V>> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, V> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         return factory;
     }
 
@@ -62,7 +77,7 @@ public class KafkaEventConfig<V extends Serializable> {
         var eventSerializer = new JsonSerializer();
         eventSerializer.setUseTypeMapperForKey(true);
 
-        return new DefaultKafkaProducerFactory<>(factoryProperties, new StringSerializer(), eventSerializer);
+        return new DefaultKafkaProducerFactory<>(producerFactoryProperties, new StringSerializer(), eventSerializer);
     }
 
     @Bean

--- a/pantry-service/pom.xml
+++ b/pantry-service/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>pantry-service</artifactId>
-    <version>0.6.10</version>
+    <version>0.6.11</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/pantry-service/src/main/java/com/fcastro/pantryservice/pantry/PantryService.java
+++ b/pantry-service/src/main/java/com/fcastro/pantryservice/pantry/PantryService.java
@@ -250,7 +250,8 @@ public class PantryService {
 
                 })
                 .filter(i -> i.getPercentage() <= 30)
-                .sorted(Comparator.comparingDouble(PantryItemChartDto::getPercentage))
+                .sorted(Comparator.comparingDouble(PantryItemChartDto::getPercentage)
+                        .thenComparing(PantryItemChartDto::getProductCode))
                 .collect(Collectors.toList());
 
         return criticalItems;

--- a/pantry-service/src/main/java/com/fcastro/pantryservice/pantryitem/PantryItemController.java
+++ b/pantry-service/src/main/java/com/fcastro/pantryservice/pantryitem/PantryItemController.java
@@ -92,8 +92,8 @@ public class PantryItemController {
     @PostMapping("/items/consume")
     @PreAuthorize("hasPermissionInObject('Pantry', #pantryItem.getPantryId(), 'consume_pantry')")
     public ResponseEntity<PantryItemDto> consumeItem(@P("pantryItem") @RequestBody PantryItemConsumedDto item) {
-        service.consumePantryItem(item);
-        return ResponseEntity.noContent().build();
+        var consumedItem = service.consumePantryItem(item);
+        return ResponseEntity.ok(consumedItem);
     }
 
     @GetMapping("/{pantryId}/items/balancing")

--- a/pantry-web/package.json
+++ b/pantry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantry-web",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "private": true,
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/pantry-web/src/assets/styles/theme.scss
+++ b/pantry-web/src/assets/styles/theme.scss
@@ -19,7 +19,7 @@
     --text-color-2: #{lighten($text-color, 35%)};
     --title-text-color: #4B0082;
     --highlight-text: #BA55D3;
-    --highlight-background: #{darken($background-color, 10%)};
+    --highlight-background: #{darken($background-color,6%)};
     --gradient-image-header: linear-gradient(to bottom right, #1E90FF -20%, #800080 100%); //dodgerblue, purple);
     --gradient-image-profile-background: linear-gradient(to bottom right, #1E90FF -30%, #800080 100%), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
     --gradient-image-icon-background: linear-gradient(to bottom right, #1E90FF -20%, #800080 100%), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
@@ -53,7 +53,7 @@
     --text-color-2: #808080;
     --title-text-color: var(--text-color);
     --highlight-text: rgb(191, 146, 254);
-    --highlight-background: #{lighten($background-color, 20%)};
+    --highlight-background: #{lighten($background-color, 11%)};
     --gradient-image-header: linear-gradient(to bottom right, #1E90FF -20%, #800080 100%); //dodgerblue, purple);
     --gradient-image-profile-background: linear-gradient(to bottom right, #1E90FF -30%, #800080 100%), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
     --gradient-image-icon-background: linear-gradient(to bottom right, #1E90FF -20%, #800080 100%), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
@@ -87,13 +87,14 @@
     --text-color-2: #808080;
     --title-text-color: var(--text-color);
     --highlight-text: #BA55D3;
-    --highlight-background: #{darken($background-color, 20%)};
+    --highlight-background: #{darken($background-color, 11%)};
     --gradient-image-header: linear-gradient(to bottom right, #808080, #000000);
     --gradient-image-profile-background: linear-gradient(180deg, #808080, #000000), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
     --gradient-image-icon-background: linear-gradient(180deg, #808080, #000000), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
     --gradient-image-button: linear-gradient(90deg, var(--background), var(--background)), linear-gradient(to bottom right, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
     --gradient-image-text: linear-gradient(45deg, rgb(34, 33, 33), rgb(34, 33, 33));
     --gradient-wizard-button-text: var(--gradient-image-text);
+    --gradient-wizard-button-border: var(--gradient-color);
     --disabled-gradient-image-button: linear-gradient(90deg, var(--background), var(--background)), linear-gradient(45deg, #808080 5%, rgb(199, 198, 198) 70%);
     --disabled-gradient-image-text: linear-gradient(45deg, #808080, #808080);
     --box-shadow-0: rgb(92, 90, 90);
@@ -120,7 +121,7 @@
     --text-color-2: #808080;
     --title-text-color: var(--text-color);
     --highlight-text: rgb(191, 146, 254);
-    --highlight-background: #{lighten($background-color, 20%)};
+    --highlight-background: #{lighten($background-color, 10%)};
     --gradient-image-header: linear-gradient(to bottom right, #808080, #000000);
     --gradient-image-profile-background: linear-gradient(180deg, #808080, #000000), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);
     --gradient-image-icon-background: linear-gradient(180deg, #808080, #000000), linear-gradient(90deg, rgba(228, 132, 252, 1) 0%, rgba(132, 212, 255, 1) 100%);

--- a/pantry-web/src/pages/Purchase.js
+++ b/pantry-web/src/pages/Purchase.js
@@ -13,6 +13,7 @@ import iconPurchase from '../assets/images/shoppingcart-gradient.png';
 import Image from 'react-bootstrap/Image';
 import { Stack } from 'react-bootstrap';
 import { PurchaseContext } from '../context/AppContext.js';
+import { RippleLoading } from '../components/RippleLoading';
 
 export default function Purchase() {
 
@@ -110,6 +111,8 @@ export default function Purchase() {
     }
 
     return (
+        <>
+        {isLoading && <RippleLoading /> }
         <Stack gap={3}>
             <div className='mt-4'>
                 <div className='d-flex justify-content-start align-items-center gap-2' onClick={() => setShowPantries(!showPantries)}>
@@ -137,16 +140,16 @@ export default function Purchase() {
             </div>
 
             <div className="d-flex justify-content-evenly align-items-start mt-0" >
-                <Button bsPrefix="btn-custom" size="sm" onClick={handleNewOrder} disabled={((!purchase && purchaseItems.length === 0) || (purchase && purchase.processedAt !== null) || isOpenOrder || pantries.length === 0)}><span>{t("btn-new-order")}</span></Button>
-                <Button bsPrefix="btn-custom" size="sm" onClick={handleRefresh} disabled={purchase || pantries.length === 0}><span>{t("btn-refresh")}</span></Button>
-                <Button bsPrefix="btn-custom" size="sm" onClick={handleCloseOrder} disabled={!isOpenOrder || pantries.length === 0}><span>{t("btn-checkout")}</span></Button>
+                <Button bsPrefix="btn-custom" size="sm" onClick={handleNewOrder} disabled={((!purchase && purchaseItems.length === 0) || (purchase && purchase.processedAt !== null) || isOpenOrder || pantries.length === 0 || isLoading)}><span>{t("btn-new-order")}</span></Button>
+                <Button bsPrefix="btn-custom" size="sm" onClick={handleRefresh} disabled={purchase || pantries.length === 0 || isLoading}><span>{t("btn-refresh")}</span></Button>
+                <Button bsPrefix="btn-custom" size="sm" onClick={handleCloseOrder} disabled={isLoading || !isOpenOrder || pantries.length === 0}><span>{t("btn-checkout")}</span></Button>
             </div>
 
             <div className='mt-2'>
-                <PurchaseItemList ref={purchaseItemListRef} selectedPurchase={purchase} selectedPantries={pantries} setOuterPurchaseItems={setPurchaseItems} />
+                <PurchaseItemList key={purchase?.id} ref={purchaseItemListRef} selectedPurchase={purchase} selectedPantries={pantries} setOuterPurchaseItems={setPurchaseItems} />
             </div>
 
         </Stack>
-
+        </>
     )
 }

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
 
     <properties>
-        <common-config-data-version>0.2.0</common-config-data-version>
+        <common-config-data-version>0.3.0</common-config-data-version>
         <security-core-version>0.1.1</security-core-version>
         <security-config-version>0.2.2</security-config-version>
 

--- a/purchase-service/pom.xml
+++ b/purchase-service/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>purchase-service</artifactId>
-    <version>0.4.7</version>
+    <version>0.4.8</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/purchase-service/src/main/java/com/fcastro/purchaseservice/config/ProductEventListener.java
+++ b/purchase-service/src/main/java/com/fcastro/purchaseservice/config/ProductEventListener.java
@@ -7,6 +7,7 @@ import com.fcastro.purchaseservice.product.ProductService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,7 +25,7 @@ public class ProductEventListener {
     }
 
     @KafkaListener(topics = "productTopic", containerFactory = "kafkaListenerContainerFactory")
-    protected void listener(ProductEvent event) {
+    protected void listener(ProductEvent event, Acknowledgment acknowledgment) {
         LOG.info("Event Received: Topic[{}], Data[{}]", kafkaConfigData.getProductTopic(), event.toString());
 
         try {
@@ -32,9 +33,12 @@ public class ProductEventListener {
                 throw new EventProcessingException("ProductEvent received, but attribute data is null.");
             }
             productService.processProductEvent(event.getData());
+
         } catch (EventProcessingException ex) {
             //TODO: What should be done? Save to reprocess later or manually?
             LOG.error(ex.getMessage());
+        } finally {
+            acknowledgment.acknowledge();
         }
     }
 }

--- a/purchase-service/src/main/java/com/fcastro/purchaseservice/config/PurchaseEventListener.java
+++ b/purchase-service/src/main/java/com/fcastro/purchaseservice/config/PurchaseEventListener.java
@@ -7,6 +7,7 @@ import com.fcastro.purchaseservice.purchaseItem.PurchaseItemService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,18 +26,23 @@ public class PurchaseEventListener {
 
     //TODO: HOW TO define <topics> getting value from configuration files?
     @KafkaListener(topics = "purchaseCreateTopic", containerFactory = "kafkaListenerContainerFactory")
-    protected void listener(PurchaseEvent event) {
+    protected void listener(PurchaseEvent event, Acknowledgment acknowledgment) {
 
-        if (event.getData() == null) {
-            LOGGER.error("PurchaseCreateEvent received, but attribute data is null.");
-            throw new EventProcessingException("PurchaseCreateEvent received, but attribute data is null.");
+        try {
+            if (event.getData() == null) {
+                LOGGER.error("PurchaseCreateEvent received, but attribute data is null.");
+                throw new EventProcessingException("PurchaseCreateEvent received, but attribute data is null.");
+            }
+
+            LOGGER.info("Event Received: Topic[{}], Data[{}]", kafkaConfigData.getPurchaseCreateTopic(), event.toString());
+
+            purchaseItemService.processPurchaseEvent(event.getData());
+
+        } catch (EventProcessingException ex) {
+            //TODO: What should be done? Save to reprocess later or manually?
+            LOGGER.error(ex.getMessage());
+        } finally {
+            acknowledgment.acknowledge();
         }
-
-        LOGGER.info("Event Received: Topic[{}], Data[{}]",
-                kafkaConfigData.getPurchaseCreateTopic(),
-                event.toString()
-        );
-
-        purchaseItemService.processPurchaseEvent(event.getData());
     }
 }

--- a/purchase-service/src/main/java/com/fcastro/purchaseservice/purchaseItem/PurchaseItemService.java
+++ b/purchase-service/src/main/java/com/fcastro/purchaseservice/purchaseItem/PurchaseItemService.java
@@ -185,7 +185,11 @@ public class PurchaseItemService {
             repository.save(entity);
 
             processPendingProvisioning(entity);
-            purchaseEventList.add(convertToItemDto(Action.UPDATE, entity));
+
+            //Event should only contain purchased Items
+            if (entity.getQtyPurchased() > 0) {
+                purchaseEventList.add(convertToItemDto(Action.UPDATE, entity));
+            }
         }
 
         return purchaseEventList;


### PR DESCRIPTION
V.0.9.9
Purchase-service
PurchaseCompleteEvent lists only purchased items
Explicitly acknowledgement of received and processed events

Pantry-service
Explicitly acknowledgement of received and processed events
Return PantryItemDto when consuming an item
Sort PantryItemChartDto by percentage and product.code

Common-config-data
Kafka Listeners: ack-mode = MANUAL-IMMEDIATE
Kafka Producers: acks = 1 (only by leader)

Pantry-web
Fix gradient-wizard-button-order and highlight-background
Add RippleLoading and disable close-purchase-button when isProcessing
Debouncing the update of currentQty 
Refresh only the consumedItem in the pantryItems list